### PR TITLE
BIB-449: Added namespace to socket

### DIFF
--- a/engine/app.js
+++ b/engine/app.js
@@ -72,6 +72,7 @@ const plugins = [
         host: config.server.host,
         port: config.server.port,
         cors: config.server.cors,
+        namespace: config.server.namespace,
         tokenEndPoint: config.tokenEndPoint,
         fbsEndPoint: config.fbsEndPoint,
         isEventExpired: isEventExpired

--- a/engine/example_config.json
+++ b/engine/example_config.json
@@ -8,6 +8,7 @@
     "server": {
         "host": "0.0.0.0",
         "port": 3000,
-        "cors": "*:*"
+        "cors": "*:*",
+        "namespace": ""
     }
 }

--- a/engine/plugins/server/server.js
+++ b/engine/plugins/server/server.js
@@ -28,6 +28,7 @@ module.exports = function(options, imports, register) {
     const port = options.port || 3000;
     const host = options.host || '0.0.0.0';
     const cors = options.cors || '*:*';
+    const namespace = options.namespace;
 
     const router = express.Router();
     const app = express();
@@ -54,7 +55,7 @@ module.exports = function(options, imports, register) {
 
     // Handle client connections in the web-socket. After connection the client should send a valid token with every
     // call to the engine.
-    io.on('connection', socket => {
+    io.of(namespace).on('connection', socket => {
         debug('Client connected with socket id: ' + socket.id);
 
         const clientConfigEvent = uniqId();


### PR DESCRIPTION
In a production environment we what to proxy the socket connection in nginx and to do this it would make sens to have it on a sub-path (eg. example.com/engine)... but the way the socket.io works make `engine` path a namespace.

So the engine will give an `invalid namespace` error, so this PR fixes that issue and makes the namespace configurable. If you don't need a namespace, as in the docker setup just leave it the empty string.