### PR TITLE
Better error handling in FBS (off-line)

### DIFF
--- a/engine/plugins/fbs/request.js
+++ b/engine/plugins/fbs/request.js
@@ -153,7 +153,7 @@ Request.prototype.send = function send(message, firstVar, callback) {
                     var sip2 = body.match(/<response>(.*)<\/response>/);
                     sip2message = sip2[1];
                 }
-                self.bus.emit('logger.info', { 'type': 'FBS', 'message': sip2message, 'xml': body });
+                self.bus.emit('logger.info', { type: 'FBS', message: sip2message, xml: body });
             }
         });
     } catch (error) {

--- a/engine/plugins/fbs/request.js
+++ b/engine/plugins/fbs/request.js
@@ -124,14 +124,14 @@ Request.prototype.send = function send(message, firstVar, callback) {
                 if (!error) {
                     res = new Response(body, firstVar);
                     if (res.hasError()) {
-                        err = new Error(res.getError());
+                        error = new Error(res.getError());
                     } else {
-                        err = new Error('Unknown error', response.statusCode());
+                        error = new Error('Unknown error', response.statusCode());
                     }
                 }
                 // Log error message from FBS.
-                self.bus.emit('logger.err', { type: 'FBS', message: err });
-                callback(error, null);
+                self.bus.emit('logger.err', { type: 'FBS', message: error });
+                callback(new Error('FBS is offline'), null);
             } else {
                 // Send debug message.
                 debug(response.statusCode + ':' + message.substr(0, 2));

--- a/engine/plugins/fbs/request.js
+++ b/engine/plugins/fbs/request.js
@@ -146,8 +146,14 @@ Request.prototype.send = function send(message, firstVar, callback) {
                 callback(err, res);
 
                 // Log message from FBS.
-                var sip2 = body.match(/<response>(.*)<\/response>/);
-                self.bus.emit('logger.info', { type: 'FBS', message: sip2 !== null ? sip2[1] : 'sip2 is null', xml: body });
+                var sip2message = 'No message';
+                if (res.hasError()) {
+                  sip2message = res.getError();
+                } else {
+                  var sip2 = body.match(/<response>(.*)<\/response>/);
+                  sip2message = sip2[1];
+                }
+                self.bus.emit('logger.info', { 'type': 'FBS', 'message': sip2message, 'xml': body});
             }
         });
     } catch (error) {

--- a/engine/plugins/fbs/request.js
+++ b/engine/plugins/fbs/request.js
@@ -148,12 +148,12 @@ Request.prototype.send = function send(message, firstVar, callback) {
                 // Log message from FBS.
                 var sip2message = 'No message';
                 if (res.hasError()) {
-                  sip2message = res.getError();
+                    sip2message = res.getError();
                 } else {
-                  var sip2 = body.match(/<response>(.*)<\/response>/);
-                  sip2message = sip2[1];
+                    var sip2 = body.match(/<response>(.*)<\/response>/);
+                    sip2message = sip2[1];
                 }
-                self.bus.emit('logger.info', { 'type': 'FBS', 'message': sip2message, 'xml': body});
+                self.bus.emit('logger.info', { 'type': 'FBS', 'message': sip2message, 'xml': body });
             }
         });
     } catch (error) {


### PR DESCRIPTION
* Index error when logging message from FBS that is an error
* Ensure that network errors results in "FBS Offline" error and logging of the error is not empty