### PR TITLE
BIBSELV-220: Added skeleton for msal provider login

### DIFF
--- a/.docker/vhost.conf
+++ b/.docker/vhost.conf
@@ -1,4 +1,7 @@
-# @see https://symfony.com/doc/current/setup/web_server_configuration.html
+upstream nodejs_engine {
+  server engine:3000;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -38,6 +41,23 @@ server {
     # this prevents access to other php files you don't want to be accessible.
     location ~ \.php$ {
         return 404;
+    }
+
+    location /engine {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_buffering off;
+
+        proxy_pass http://nodejs_engine;
+    }
+
+    location /socket.io/ {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_pass http://nodejs_engine;
     }
 
     error_log /var/log/nginx/project_error.log;

--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ COMPOSE_DOMAIN=bibbox-website.local.itkdev.dk
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=c7ee3dec8aca579a5679a16ff141161b
-#TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+TRUSTED_PROXIES=127.0.0.0/8,REMOTE_ADDR
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 ###< symfony/framework-bundle ###
 
@@ -34,6 +34,6 @@ DATABASE_URL=mysql://db:db@mariadb:3306/db
 ###< doctrine/doctrine-bundle ###
 
 ###> custom ###
-ENGINE_SOCKET_URI=http://bibbox-website.local.itkdev.dk:8030/
+ENGINE_SOCKET_URI=https://bibbox-website.local.itkdev.dk/
 TOKEN_EXPIRE_SECONDS=86400
 ###< custom ###

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Next access the React frontend where `x` below is the id of the configuration en
 open http://$(docker-compose port nginx 80)?id=x
 ```
 
+### Azure AD login
+For working with the Azure Ad login in your local dev environment you need access the box from a URL that qualifies as "secure origin". This means either `https`, `127.0.0.1` or `localhost`. The standard `0.0.0.0` docker IP does not qualify.
+
+Using a non-secure origin will result in browser errors like:
+`BrowserAuthError: pkce_not_created: The PKCE code challenge and verifier could not be generated. Detail:TypeError: can't access property "digest", window.crypto.subtle is undefined`
+
 ## Logging
 The engine uses logstash to log messages, and these can be seen in the docker setup with the following command.
 ```sh

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -11,8 +11,8 @@ import Loading from './steps/loading';
 import { IntlProvider } from 'react-intl';
 import Alert from './steps/utils/alert';
 import { AppTokenNotValid, ServerError } from './steps/utils/formatted-messages';
-import {AZURE_AD_LOGIN, CONNECTION_OFFLINE, CONNECTION_ONLINE} from './constants';
-import MsalProviderWrapper from "./steps/msal-provider-wrapper";
+import { AZURE_AD_LOGIN, CONNECTION_OFFLINE, CONNECTION_ONLINE } from './constants';
+import MsalProviderWrapper from './steps/msal-provider-wrapper';
 
 /**
  * App. The main entrypoint of the react application.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -11,7 +11,8 @@ import Loading from './steps/loading';
 import { IntlProvider } from 'react-intl';
 import Alert from './steps/utils/alert';
 import { AppTokenNotValid, ServerError } from './steps/utils/formatted-messages';
-import { CONNECTION_OFFLINE, CONNECTION_ONLINE } from './constants';
+import {AZURE_AD_LOGIN, CONNECTION_OFFLINE, CONNECTION_ONLINE} from './constants';
+import MsalProviderWrapper from "./steps/msal-provider-wrapper";
 
 /**
  * App. The main entrypoint of the react application.
@@ -309,6 +310,32 @@ function App({ uniqueId, socket }) {
         });
     }
 
+    /**
+     * Render box depending on auth method. Azure Ad auth requires that the box be wrapped a MsalProvider.
+     *
+     * @param boxConfig
+     *
+     * @return {JSX.Element}
+     */
+    function renderBox(boxConfig) {
+        switch (boxConfig.loginMethod) {
+            case AZURE_AD_LOGIN:
+                return <MsalProviderWrapper
+                    boxConfigurationInput={boxConfig}
+                    machineStateInput={machineState}
+                    connectionState={connectionState}
+                    actionHandler={handleAction}
+                />;
+            default:
+                return <Bibbox
+                    boxConfigurationInput={boxConfig}
+                    machineStateInput={machineState}
+                    connectionState={connectionState}
+                    actionHandler={handleAction}
+                />;
+        }
+    }
+
     return (
         <IntlProvider locale={language} messages={messages}>
             {machineState && boxConfig && !errorMessage && (
@@ -320,12 +347,7 @@ function App({ uniqueId, socket }) {
                         eventsThrottle={500}
                         timeout={boxConfig.inactivityTimeOut}
                     />
-                    <Bibbox
-                        boxConfigurationInput={boxConfig}
-                        machineStateInput={machineState}
-                        connectionState={connectionState}
-                        actionHandler={handleAction}
-                    />
+                    {renderBox(boxConfig)}
                 </div>
             )}
             {errorMessage && <Alert message={errorMessage}/>}

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -29,3 +29,8 @@ export const ACTION_CHANGE_FLOW_STATUS = 'changeFlowStatus';
 // Connection constants
 export const CONNECTION_ONLINE = 'online';
 export const CONNECTION_OFFLINE = 'offline';
+
+// Login method constants
+export const LOGIN_BARCODE = 'login_barcode';
+export const LOGIN_BARCODE_PASSWORD = 'login_barcode_password';
+export const AZURE_AD_LOGIN = 'azure_ad_login';

--- a/assets/js/steps/login-components/authConfig.js
+++ b/assets/js/steps/login-components/authConfig.js
@@ -1,0 +1,15 @@
+// Config object to be passed to Msal on creation
+export const msalConfig = {
+    auth: {
+        clientId: 'cda8b05e-baf1-461e-9d15-7438d5b6180d',
+        authority: 'https://aarhuskommunetest.b2clogin.com/aarhuskommunetest.onmicrosoft.com/B2C_1A_AAK_SIGNIN_OIDC_BIBSELV/oauth2/v2.0/authorize',
+        knownAuthorities: ['aarhuskommunetest.b2clogin.com'],
+        redirectUri: 'http://localhost:4200',
+        postLogoutRedirectUri: 'http://localhost:4200'
+    }
+};
+
+// Scopes you add here will be prompted for consent during login
+export const loginRequest = {
+    scopes: ['https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read']
+};

--- a/assets/js/steps/login-components/authConfig.js
+++ b/assets/js/steps/login-components/authConfig.js
@@ -2,14 +2,15 @@
 export const msalConfig = {
     auth: {
         clientId: 'cda8b05e-baf1-461e-9d15-7438d5b6180d',
-        authority: 'https://aarhuskommunetest.b2clogin.com/aarhuskommunetest.onmicrosoft.com/B2C_1A_AAK_SIGNIN_OIDC_BIBSELV/oauth2/v2.0/authorize',
+        authority: 'https://aarhuskommunetest.b2clogin.com/aarhuskommunetest.onmicrosoft.com/B2C_1A_AAK_SIGNIN_OIDC_BIBSELV',
         knownAuthorities: ['aarhuskommunetest.b2clogin.com'],
-        redirectUri: 'http://localhost:4200',
-        postLogoutRedirectUri: 'http://localhost:4200'
+        redirectUri: 'https://bibbox-website.local.itkdev.dk/oidc',
+        postLogoutRedirectUri: 'https://bibbox-website.local.itkdev.dk/oidc'
     }
 };
 
 // Scopes you add here will be prompted for consent during login
 export const loginRequest = {
-    scopes: ['https://fabrikamb2c.onmicrosoft.com/helloapi/demo.read']
+    scopes: ['https://aarhuskommunetest.onmicrosoft.com/B2C_1A_AAK_SIGNIN_OIDC_BIBSELV/openid'],
+    state: 'uniqueID'
 };

--- a/assets/js/steps/login-components/azure-ad-login.js
+++ b/assets/js/steps/login-components/azure-ad-login.js
@@ -33,7 +33,6 @@ function AzureAdLogin({ actionHandler }) {
      */
     useEffect(() => {
         if (!isAuthenticated) {
-            let d = 1;
             instance.loginRedirect(loginRequest).catch(e => {
                 console.error(e);
             });
@@ -60,12 +59,11 @@ function AzureAdLogin({ actionHandler }) {
 
     return (
         <>
-            <p>Hello World!</p>
             <AuthenticatedTemplate>
-                <p>You are signed in - </p>
+                <p>You are signed in</p>
             </AuthenticatedTemplate>
             <UnauthenticatedTemplate>
-                <p>You are not signed in - Please sign in.</p>
+                <p>You are not signed in - Please sign in</p>
             </UnauthenticatedTemplate>
         </>
     );

--- a/assets/js/steps/login-components/azure-ad-login.js
+++ b/assets/js/steps/login-components/azure-ad-login.js
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * For Boxes that login through Azure AD.
+ */
+
+import React, { useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
+import MachineStateContext from '../utils/machine-state-context';
+import { AuthenticatedTemplate, UnauthenticatedTemplate, useIsAuthenticated, useMsal } from '@azure/msal-react';
+import { ACTION_RESET } from '../../constants';
+import BarcodeHandler from '../utils/barcode-handler';
+import BarcodeScanner from '../utils/barcode-scanner';
+import { loginRequest } from './authConfig';
+
+/**
+ * Azure AD login component.
+ *
+ * Redirects to Azure Ad for login
+ *
+ * @param actionHandler
+ *  As the state can only be changed by the state machine, the actionHandler
+ *  calls the state machine if a user requests a state change.
+ * @return {*}
+ * @constructor
+ */
+function AzureAdLogin({ actionHandler }) {
+    const context = useContext(MachineStateContext);
+    const isAuthenticated = useIsAuthenticated();
+    const { instance } = useMsal();
+
+    /**
+     * Redirect to Azure AD
+     */
+    useEffect(() => {
+        if (!isAuthenticated) {
+            let d = 1;
+            instance.loginRedirect(loginRequest).catch(e => {
+                console.error(e);
+            });
+        }
+    });
+
+    /**
+     * Setup barcode scanner.
+     */
+    useEffect(() => {
+        const barcodeScanner = new BarcodeScanner();
+        const barcodeCallback = (new BarcodeHandler([
+            ACTION_RESET
+        ], actionHandler, function(result) {
+            actionHandler('login', {
+                username: result.outputCode,
+                useDefaultPassword: true
+            });
+        })).createCallback();
+
+        barcodeScanner.start(barcodeCallback);
+        return () => { barcodeScanner.stop(); };
+    }, [actionHandler]);
+
+    return (
+        <>
+            <p>Hello World!</p>
+            <AuthenticatedTemplate>
+                <p>You are signed in - </p>
+            </AuthenticatedTemplate>
+            <UnauthenticatedTemplate>
+                <p>You are not signed in - Please sign in.</p>
+            </UnauthenticatedTemplate>
+        </>
+    );
+}
+
+AzureAdLogin.propTypes = {
+    actionHandler: PropTypes.func.isRequired
+};
+
+export default AzureAdLogin;

--- a/assets/js/steps/login.js
+++ b/assets/js/steps/login.js
@@ -9,13 +9,14 @@ import ScanLogin from './login-components/scan-login';
 import ScanPasswordLogin from './login-components/scan-password-login';
 import { LoginLoginNotConfigured } from './utils/formatted-messages';
 import MachineStateContext from './utils/machine-state-context';
+import AzureAdLogin from './login-components/azure-ad-login';
 
 /**
  * Renders a login component based on configuration
  *
  * @param actionHandler
- *  As the state can only be changed by the statemachine, the actionHandler
- *  calls the statemachine if a user requests a state change.
+ *  As the state can only be changed by the state machine, the actionHandler
+ *  calls the state machine if a user requests a state change.
  * @return {*}
  * @constructor
  */
@@ -37,6 +38,12 @@ function Login({ actionHandler }) {
             case 'login_barcode_password':
                 return (
                     <ScanPasswordLogin
+                        actionHandler={actionHandler}
+                    />
+                );
+            case 'azure_ad_login':
+                return (
+                    <AzureAdLogin
                         actionHandler={actionHandler}
                     />
                 );

--- a/assets/js/steps/msal-provider-wrapper.js
+++ b/assets/js/steps/msal-provider-wrapper.js
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * MsalProvider for Boxes that login through Azure AD.
+ */
+
+import React from 'react';
+import { msalConfig } from './login-components/authConfig';
+import { PublicClientApplication } from '@azure/msal-browser';
+import PropTypes from 'prop-types';
+import Bibbox from './bibbox';
+import { MsalProvider } from '@azure/msal-react';
+
+/**
+ * Msal Provider wrapper.
+ *
+ * @param boxConfigurationInput
+ *   The configuration of the bibbox.
+ * @param machineStateInput
+ *   The state of the app.
+ * @param actionHandler
+ *   Callback on requested state change.
+ * @param connectionState
+ *   Connection state.
+ *
+ * @return {*}
+ * @constructor
+ */
+function MsalProviderWrapper({ boxConfigurationInput, machineStateInput, actionHandler, connectionState }) {
+    const msalInstance = new PublicClientApplication(msalConfig);
+
+    return (
+        <MsalProvider instance={msalInstance}>
+            <Bibbox
+                boxConfigurationInput={boxConfigurationInput}
+                machineStateInput={machineStateInput}
+                connectionState={connectionState}
+                actionHandler={actionHandler}
+            />
+        </MsalProvider>
+    );
+}
+
+MsalProviderWrapper.propTypes = {
+    boxConfigurationInput: PropTypes.object.isRequired,
+    machineStateInput: PropTypes.object.isRequired,
+    connectionState: PropTypes.string.isRequired,
+    actionHandler: PropTypes.func.isRequired
+};
+
+export default MsalProviderWrapper;

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -3,6 +3,8 @@ framework:
     #csrf_protection: true
     #http_method_override: true
 
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
+
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,11 @@ services:
       - frontend
     depends_on:
       - phpfpm
+      - engine'
     ports:
       - '80'
+      - '8000:80'
+      - '443'
     volumes:
       - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
@@ -55,6 +58,7 @@ services:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.tls=true"
 
   engine:
     image: node:14
@@ -63,12 +67,8 @@ services:
     working_dir: /app
     environment:
       - NODE_ENV=development
-    depends_on:
-      - nginx
     volumes:
       - ./engine:/app:delegated
-    ports:
-      - '8030:3000'
     command: npm run dev
 
   frontend:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,27 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@azure/msal-browser": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.16.1.tgz",
+            "integrity": "sha512-PcYi4seUGdtu30mOIdwk4FvbOdHFQ+fKAptEqV0tcsrvor0Hox/R0Xr0GEiBMfKkJbagLOYX7ORPRCYhZrWeqw==",
+            "requires": {
+                "@azure/msal-common": "^4.5.1"
+            }
+        },
+        "@azure/msal-common": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
+            "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
+            "requires": {
+                "debug": "^4.1.1"
+            }
+        },
+        "@azure/msal-react": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-1.0.1.tgz",
+            "integrity": "sha512-5e5+DYnu3/a9R/QUrH7rWKmq1UjYY13kSW0TAWZTf+GEUjIcV/+cJtTVg0RNBACIWU8PAVW8Epj3qfgPDfOctg=="
+        },
         "@babel/code-frame": {
             "version": "7.10.3",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
@@ -8706,7 +8727,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -17342,8 +17362,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multicast-dns": {
             "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,8 @@
         ]
     },
     "dependencies": {
+        "@azure/msal-browser": "^2.16.1",
+        "@azure/msal-react": "^1.0.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.29",
         "@fortawesome/free-regular-svg-icons": "^5.14.0",
         "@fortawesome/free-solid-svg-icons": "^5.13.1",

--- a/src/Controller/OidcRedirectUrlController.php
+++ b/src/Controller/OidcRedirectUrlController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class OidcRedirectUrlController extends AbstractController
+{
+    /**
+     * @Route("/oidc", name="oidc_redirect_url", priority=10)
+     */
+    public function index(): Response
+    {
+        return $this->render('oidc_redirect_url/index.html.twig', [
+            'controller_name' => 'OidcRedirectUrlController',
+        ]);
+    }
+}

--- a/src/Utils/Types/LoginMethods.php
+++ b/src/Utils/Types/LoginMethods.php
@@ -9,7 +9,7 @@ class LoginMethods
 {
     public const LOGIN_BARCODE = 'login_barcode';
     public const LOGIN_BARCODE_PASSWORD = 'login_barcode_password';
-    public const UNILOGIN = 'unilogin';
+    public const AZURE_AD_LOGIN = 'azure_ad_login';
 
     /**
      * Get array of all defined login methods.

--- a/templates/oidc_redirect_url/index.html.twig
+++ b/templates/oidc_redirect_url/index.html.twig
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Bibbox frontend" />
+    <link rel="apple-touch-icon" href="logo192.png" />
+    <title>Bibbox</title>
+</head>
+<body>
+<script>
+    let uniqueId = localStorage.getItem('uniqueId');
+    let hash = window.location.hash;
+    window.location.replace('/' + uniqueId + hash);
+</script>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+</body>
+</html>


### PR DESCRIPTION
Incomplete implementation:
* Have added skeleton for ad login using `MsalProvider`
* Might need different `authority` url for config. See note in ticket

Note that this must be run via `httpS` or from `localhost` / `127.0.0.1` when developing locally. If not you will get errors from underlying auth libs.

Links:
https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-javascript-auth-code-react
