### PR TITLE
BIBSELV-266: Handle AzureAdException

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cp engine/example_config.json engine/config.json
 Install dependencies for the engine.
 
 ```sh
-docker-compose run engine bash -c './scripts/install.sh'
+docker-compose run engine bash -c './scripts/install.sh dev'
 ```
 
 ### Environment variables
@@ -86,6 +86,20 @@ Install database schema for Symfony using migrations, run
 ```sh
 docker-compose exec phpfpm bash -c 'bin/console doctrine:migrations:migrate'
 ```
+
+To populate the databasde with meaningful test data run the doctrine fixtures
+
+```sh
+docker-compose exec phpfpm bash -c 'bin/console doctrine:fixtures:load'
+```
+
+To create a test user run
+
+```sh
+docker-compose exec phpfpm bash -c 'bin/console app:user:create --email=admin@example.com --password=admin'
+```
+
+
 
 ### Restart
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cp engine/example_config.json engine/config.json
 Install dependencies for the engine.
 
 ```sh
-docker-compose run engine bash -c './scripts/install.sh dev'
+docker-compose run engine bash -c './scripts/install.sh --also=dev'
 ```
 
 ### Environment variables

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -1,7 +1,7 @@
 monolog:
     handlers:
         security:
-            level: info
+            level: error
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%_security.log'
             channels: [ security ]

--- a/src/Controller/BoxAdLoginController.php
+++ b/src/Controller/BoxAdLoginController.php
@@ -7,6 +7,7 @@
 
 namespace App\Controller;
 
+use App\Exception\AzureAdException;
 use App\Service\AzureAdService;
 use ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException;
 use ItkDev\OpenIdConnect\Exception\ValidationException;
@@ -95,10 +96,11 @@ class BoxAdLoginController extends AbstractController
             $boxUrl = $this->generateUrl('box_frontend_load', ['uniqueId' => $loginState->boxId]);
 
             return new RedirectResponse($boxUrl);
-        } catch (ValidationException|InvalidArgumentException|InvalidProviderException $exception) {
+        } catch (\Exception|InvalidArgumentException $exception) {
             $session->set('exceptionMessage', $exception->getMessage());
 
             $this->securityLogger->error($exception);
+            $this->securityLogger->error($request);
 
             return $this->redirectToRoute('app_box_error');
         }

--- a/src/Controller/BoxAdLoginController.php
+++ b/src/Controller/BoxAdLoginController.php
@@ -97,7 +97,12 @@ class BoxAdLoginController extends AbstractController
 
             return new RedirectResponse($boxUrl);
         } catch (\Exception|InvalidArgumentException $exception) {
+            $error = $request->query->get('error');
+            $errorDescription = urldecode($request->query->get('error_description'));
+
             $session->set('exceptionMessage', $exception->getMessage());
+            $session->set('error', 'Azure Ad: '.$error);
+            $session->set('errorDescription', $errorDescription);
 
             $this->securityLogger->error($exception);
             $this->securityLogger->error($request);

--- a/src/Controller/BoxAdLoginController.php
+++ b/src/Controller/BoxAdLoginController.php
@@ -7,10 +7,8 @@
 
 namespace App\Controller;
 
-use App\Exception\AzureAdException;
 use App\Service\AzureAdService;
 use ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException;
-use ItkDev\OpenIdConnect\Exception\ValidationException;
 use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
 use Psr\Cache\InvalidArgumentException;
 use Psr\Log\LoggerInterface;

--- a/src/Controller/BoxErrorController.php
+++ b/src/Controller/BoxErrorController.php
@@ -58,7 +58,7 @@ class BoxErrorController extends AbstractController
             'boxName' => $boxName,
             'exceptionMessage' => $exceptionMessage,
             'error' => $error,
-            'errorDescription' => nl2br($errorDescription),
+            'errorDescription' => $errorDescription,
         ]);
     }
 }

--- a/src/Controller/BoxErrorController.php
+++ b/src/Controller/BoxErrorController.php
@@ -39,6 +39,8 @@ class BoxErrorController extends AbstractController
     {
         $uniqueId = $session->get('boxId');
         $exceptionMessage = $session->get('exceptionMessage');
+        $error = $session->get('error');
+        $errorDescription = $session->get('errorDescription');
 
         if (null !== $uniqueId) {
             $boxUrl = $this->generateUrl('box_frontend_load', ['uniqueId' => $uniqueId], UrlGeneratorInterface::ABSOLUTE_URL);
@@ -55,6 +57,8 @@ class BoxErrorController extends AbstractController
             'boxUrl' => $boxUrl,
             'boxName' => $boxName,
             'exceptionMessage' => $exceptionMessage,
+            'error' => $error,
+            'errorDescription' => $errorDescription,
         ]);
     }
 }

--- a/src/Controller/BoxErrorController.php
+++ b/src/Controller/BoxErrorController.php
@@ -58,7 +58,7 @@ class BoxErrorController extends AbstractController
             'boxName' => $boxName,
             'exceptionMessage' => $exceptionMessage,
             'error' => $error,
-            'errorDescription' => $errorDescription,
+            'errorDescription' => nl2br($errorDescription),
         ]);
     }
 }

--- a/src/Service/AzureAdService.php
+++ b/src/Service/AzureAdService.php
@@ -6,7 +6,6 @@ use App\Exception\AzureAdException;
 use App\Utils\AdLoginState;
 use App\Utils\Types\BoxFlowStates;
 use ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException;
-use ItkDev\OpenIdConnect\Exception\ValidationException;
 use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
 use Psr\Cache\InvalidArgumentException;
@@ -64,7 +63,7 @@ class AzureAdService
     {
         $provider = $this->providerManager->getProvider(self::AZURE_AD_KEY);
         $session = $this->requestStack->getSession();
-        $boxState = $uniqueId.':'.$boxState;
+        $boxState = $uniqueId . ':' . $boxState;
 
         $nonce = $provider->generateNonce();
         $session->set('oauth2nonce', $nonce);

--- a/src/Service/AzureAdService.php
+++ b/src/Service/AzureAdService.php
@@ -92,7 +92,7 @@ class AzureAdService
      *
      * @return AdLoginState
      *
-     * @throws ValidationException|InvalidProviderException
+     * @throws AzureAdException
      */
     public function getAdLoginState(Request $request): AdLoginState
     {

--- a/templates/box_error/index.html.twig
+++ b/templates/box_error/index.html.twig
@@ -36,7 +36,7 @@
                             <dt class="col-sm-2">{{ 'Error Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ error ?? 'Unknown' }}</dd>
                             <dt class="col-sm-2">{{ 'Error Description' | trans}}</dt>
-                            <dd class="col-sm-10">{{ errorDescription ?? 'Unknown' }}</dd>
+                            <dd class="col-sm-10">{{ errorDescription | nl2br ?? 'Unknown' }}</dd>
                         {% else %}
                             <dt class="col-sm-2">{{ 'Exception Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ exceptionMessage ?? 'Unknown' }}</dd>

--- a/templates/box_error/index.html.twig
+++ b/templates/box_error/index.html.twig
@@ -13,14 +13,21 @@
             </div>
             <div class="container-md">
                 <div class="alert alert-danger" role="alert">
-                    <h4 class="alert-heading">{{ 'An error occurred while logging in:'|trans }}</h4>
                     <dl class="row">
                         <dt class="col-sm-2">{{ 'Box Id' | trans }}</dt>
                         <dd class="col-sm-10">{{ boxId ?? 'Unknown' }}</dd>
                         <dt class="col-sm-2">{{ 'Box Name' | trans}}</dt>
                         <dd class="col-sm-10">{{ boxName ?? 'Unknown' }}</dd>
-                        <dt class="col-sm-2">{{ 'Error Message' | trans}}</dt>
-                        <dd class="col-sm-10">{{ exceptionMessage ?? 'Unknown' }}</dd>
+                        <h4 class="alert-heading">{{ 'An error occurred while logging in:'|trans }}</h4>
+                        {% if errorDescription %}
+                            <dt class="col-sm-2">{{ 'Error Message' | trans}}</dt>
+                            <dd class="col-sm-10">{{ error ?? 'Unknown' }}</dd>
+                            <dt class="col-sm-2">{{ 'Error Description' | trans}}</dt>
+                            <dd class="col-sm-10">{{ errorDescription ?? 'Unknown' }}</dd>
+                        {% else %}
+                            <dt class="col-sm-2">{{ 'Exception Message' | trans}}</dt>
+                            <dd class="col-sm-10">{{ exceptionMessage ?? 'Unknown' }}</dd>
+                        {% endif %}
                     </dl>
                     <hr>
                     <p class="mb-0">{{ 'now' | date('Y-m-d\TH:i:sO') }} - {{ 'The error has been logged for debugging.' | trans }}</p>

--- a/templates/box_error/index.html.twig
+++ b/templates/box_error/index.html.twig
@@ -5,13 +5,29 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-        function redirect () {
-            setTimeout(myURL, 5000);
-        }
+        let seconds = 30; // seconds for HTML
+        let foo; // variable for clearInterval() function
 
-        function myURL() {
+        function redirect() {
             document.location.href = '{{ boxUrl }}';
         }
+
+        function updateSecs() {
+            document.getElementById("seconds").innerHTML = seconds.toString();
+            seconds--;
+            if (seconds == -1) {
+                clearInterval(foo);
+                redirect();
+            }
+        }
+
+        function countdownTimer() {
+            foo = setInterval(function () {
+                updateSecs()
+            }, 1000);
+        }
+
+        countdownTimer();
     </script>
 {% endblock %}
 
@@ -36,7 +52,7 @@
                             <dt class="col-sm-2">{{ 'Error Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ error ?? 'Unknown' }}</dd>
                             <dt class="col-sm-2">{{ 'Error Description' | trans}}</dt>
-                            <dd class="col-sm-10">{{ errorDescription | nl2br ?? 'Unknown' }}</dd>
+                            <dd class="col-sm-10">{{ errorDescription ?? 'Unknown' }}</dd>
                         {% else %}
                             <dt class="col-sm-2">{{ 'Exception Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ exceptionMessage ?? 'Unknown' }}</dd>
@@ -47,12 +63,14 @@
                 </div>
             </div>
             <div class="container-md pt-4">
-                <p class="text-center">
-                    {% if boxUrl %}
+                {% if boxUrl %}
+                    <p class="text-center">
                         <a class="btn btn-outline-dark" href="{{ boxUrl }}" role="button">◀ {{ 'Return to box' | trans }}</a>
-                    {% else %}
-                        {{ 'Please restart your browser' | trans }}
-                    {% endif %}
+                    </p>
+                    <p class="text-center text-muted">The box should automatically reload in <span id="seconds">7</span> seconds.</p>
+                {% else %}
+                    <p class="text-center">{{ 'Please restart your browser' | trans }}</p>
+                {% endif %}
                 </p>
             </div>
         </div>

--- a/templates/box_error/index.html.twig
+++ b/templates/box_error/index.html.twig
@@ -52,7 +52,7 @@
                             <dt class="col-sm-2">{{ 'Error Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ error ?? 'Unknown' }}</dd>
                             <dt class="col-sm-2">{{ 'Error Description' | trans}}</dt>
-                            <dd class="col-sm-10">{{ errorDescription ?? 'Unknown' }}</dd>
+                            <dd class="col-sm-10">{{ errorDescription | nl2br }}</dd>
                         {% else %}
                             <dt class="col-sm-2">{{ 'Exception Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ exceptionMessage ?? 'Unknown' }}</dd>

--- a/templates/box_error/index.html.twig
+++ b/templates/box_error/index.html.twig
@@ -2,6 +2,19 @@
 
 {% block title %}{{ boxName ?? 'Bibbox'}}: {{ 'Error' | trans }}{% endblock %}
 
+{% block javascripts %}
+    {{ parent() }}
+    <script>
+        function redirect () {
+            setTimeout(myURL, 5000);
+        }
+
+        function myURL() {
+            document.location.href = '{{ boxUrl }}';
+        }
+    </script>
+{% endblock %}
+
 {% block body %}
     <div class="root">
         <div>
@@ -13,12 +26,12 @@
             </div>
             <div class="container-md">
                 <div class="alert alert-danger" role="alert">
+                    <h4 class="alert-heading">{{ 'An error occurred while logging in:'|trans }}</h4>
                     <dl class="row">
                         <dt class="col-sm-2">{{ 'Box Id' | trans }}</dt>
                         <dd class="col-sm-10">{{ boxId ?? 'Unknown' }}</dd>
                         <dt class="col-sm-2">{{ 'Box Name' | trans}}</dt>
                         <dd class="col-sm-10">{{ boxName ?? 'Unknown' }}</dd>
-                        <h4 class="alert-heading">{{ 'An error occurred while logging in:'|trans }}</h4>
                         {% if errorDescription %}
                             <dt class="col-sm-2">{{ 'Error Message' | trans}}</dt>
                             <dd class="col-sm-10">{{ error ?? 'Unknown' }}</dd>


### PR DESCRIPTION
Issue: https://jira.itkdev.dk/browse/BIBSELV-266

* Fix exception handling for oidc endpoint to ensure errorpage is shown on failed logins 
* Added Azure error description to error page
* Added redirect to box after 30 secs

I have no explanation for the code style errors. They even appear in files untouched by this PR and relate to the concat operator:
```
$sip2user->setAgencyId('DK-'.$libraryNumber);
```
Results in
```
92 | ERROR | [x] Expected at least 1 space before "."; 0 found
```

Changing it to 
```
$sip2user->setAgencyId('DK-' . $libraryNumber);
```
Results in
```
92 | ERROR | [x] Concat operator must not be surrounded by spaces
```
🤬